### PR TITLE
implementation of new styling and temp styling for chat history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "LocalChat",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/web_app/src/components/Layout.jsx
+++ b/web_app/src/components/Layout.jsx
@@ -71,6 +71,7 @@ function Layout(props) {
     setRenamingId(null);
   };
 
+  // this may need to be changed, the dropdown menu for chat histories is very messy and temporary.
   // toggle dropdown menu
   const toggleMenu = (chatId) => {
     setOpenMenuId(openMenuId() === chatId ? null : chatId);
@@ -83,7 +84,7 @@ function Layout(props) {
     }
   };
 
-  // Add click listener to close menu when clicking outside
+  // add click listener to close menu when clicking outside
   createEffect(() => {
     if (openMenuId()) {
       document.addEventListener('click', handleClickOutside);

--- a/web_app/src/components/Layout.jsx
+++ b/web_app/src/components/Layout.jsx
@@ -21,6 +21,9 @@ function Layout(props) {
   // hover state for mouse navigation of chats
   const [hoveredChatId, setHoveredChatId] = createSignal(null);
   
+  // state for dropdown menu
+  const [openMenuId, setOpenMenuId] = createSignal(null);
+  
   // updates the chat history
   createEffect(() => {
     let chatList = getChatHistories();
@@ -41,6 +44,7 @@ function Layout(props) {
     if (location.pathname.includes(chatId)) {
       navigate('/');
     }
+    setOpenMenuId(null); // Close menu after action
   };
 
   const deleteAllChats = () => {
@@ -57,6 +61,7 @@ function Layout(props) {
     setRenamingId(chatId);
     const chat = chatHistories().find(c => c.chatId === chatId);
     setNewTitle(chat?.title || chat.chatId);
+    setOpenMenuId(null); // Close menu when starting rename
   };
 
   // apply and save new title
@@ -65,6 +70,30 @@ function Layout(props) {
     setChatHistories(getChatHistories());
     setRenamingId(null);
   };
+
+  // toggle dropdown menu
+  const toggleMenu = (chatId) => {
+    setOpenMenuId(openMenuId() === chatId ? null : chatId);
+  };
+
+  // close menu when clicking outside
+  const handleClickOutside = (e) => {
+    if (!e.target.closest(`.${styles.menuContainer}`)) {
+      setOpenMenuId(null);
+    }
+  };
+
+  // Add click listener to close menu when clicking outside
+  createEffect(() => {
+    if (openMenuId()) {
+      document.addEventListener('click', handleClickOutside);
+    } else {
+      document.removeEventListener('click', handleClickOutside);
+    }
+    
+    // Cleanup
+    return () => document.removeEventListener('click', handleClickOutside);
+  });
 
   return (
     <>
@@ -93,9 +122,39 @@ function Layout(props) {
                     >
                       {chat.chatName}
                     </A>
-                    <div>
-                      <button onClick={() => startRenaming(chat.chatId)}>Rename</button>
-                      <button onClick={() => deleteChat(chat.chatId)}>Delete</button>
+                    <div class={styles.menuContainer}>
+                      <button 
+                        class={styles.menuButton}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          toggleMenu(chat.chatId);
+                        }}
+                      >
+                        ⋯
+                      </button>
+                      <Show when={openMenuId() === chat.chatId}>
+                        <div class={styles.dropdown}>
+                          <button 
+                            class={styles.dropdownItem}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              startRenaming(chat.chatId);
+                            }}
+                          >
+                            Rename
+                          </button>
+                          <button 
+                            class={styles.dropdownItem}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              deleteChat(chat.chatId);
+                            }}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </Show>
                     </div>
                   </div>
                 }

--- a/web_app/src/components/Layout.module.css
+++ b/web_app/src/components/Layout.module.css
@@ -44,7 +44,7 @@
     border: 1px solid lightgrey;
 }
 
-/* Menu container and button styles */
+/* menu container and the new PLACEHOLDER button styles, this is very messy and very temporary will be changed later*/
 .menuContainer {
     position: relative;
     display: flex;
@@ -73,7 +73,7 @@
     background-color: rgba(255, 255, 255, 0.2);
 }
 
-/* Dropdown menu styles */
+/* dropdown menu styles */
 .dropdown {
     position: absolute;
     top: 100%;

--- a/web_app/src/components/Layout.module.css
+++ b/web_app/src/components/Layout.module.css
@@ -43,3 +43,77 @@
     background-color: grey;
     border: 1px solid lightgrey;
 }
+
+/* Menu container and button styles */
+.menuContainer {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.menuButton {
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 16px;
+    font-weight: bold;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    transition: all 0.2s ease;
+    line-height: 1;
+}
+
+.menuButton:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.menuButton:active {
+    background-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Dropdown menu styles */
+.dropdown {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background-color: #2a2a2a;
+    border: 1px solid #404040;
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    z-index: 1000;
+    min-width: 120px;
+    padding: 4px 0;
+    margin-top: 4px;
+}
+
+.dropdownItem {
+    display: block;
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: #ffffff;
+    padding: 8px 16px;
+    text-align: left;
+    cursor: pointer;
+    font-size: 14px;
+    transition: background-color 0.2s ease;
+}
+
+.dropdownItem:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+.dropdownItem:active {
+    background-color: rgba(255, 255, 255, 0.2);
+}
+
+/* styling for delete button */
+.dropdownItem:last-child {
+    color: #ff6b6b;
+}
+
+.dropdownItem:last-child:hover {
+    background-color: rgba(255, 107, 107, 0.1);
+}

--- a/web_app/src/components/chats/chat-functionalities/Summarize.jsx
+++ b/web_app/src/components/chats/chat-functionalities/Summarize.jsx
@@ -16,12 +16,6 @@ function Summarize() {
 
   const [tab, setTab] = createSignal("text");
 
-  // Remove the autoResize function since we want fixed size
-  // const autoResize = (textarea) => {
-  //   textarea.style.height = 'auto';
-  //   textarea.style.height = Math.max(textarea.scrollHeight, 50) + 'px'; // minimum height of 50px
-  // };
-
   const setupModel = async () => {
 
     // disable uploading another model, and change the text to indicate a model is being loaded.
@@ -112,9 +106,6 @@ function Summarize() {
 
     chatContext.addMessage("Summarize: " + userMessage, true);
     inputTextArea.value = "";
-    
-    // No need to resize since we want fixed size
-    // autoResize(inputTextArea);
 
     let messageDate = chatContext.addMessage("Generating Message...", false, selectedModel());  // temporary message to indicate progress
     let output = await generator(userMessage, { max_new_tokens: 100});  // generate response
@@ -161,25 +152,7 @@ function Summarize() {
     <>
       <div class={styles.inputContainer}>
 
-        {/* header row */}
-        <label for="folderInput" id="modelInputLabel" class={selectedModel() === "" ? styles.unselectedModelButton : styles.selectedModelButton}>
-          {selectedModel() === "" ? "Select Model" : selectedModel()}
-        </label>
-        <input type="file" id="folderInput" class={styles.hidden} webkitdirectory multiple onChange={setupModel} />
-        <button 
-          class={tab() === "file" ? styles.selectedTab : styles.tab}
-          onClick={() => setTab("file")}
-        >
-          Summarize File
-        </button>
-        <button 
-          class={tab() === "text" ? styles.selectedTab : styles.tab}
-          onClick={() => setTab("text")}
-        >
-          Summarize Text
-        </button>
-
-        {/* dynamic input UI */}
+        {/* Dynamic input UI - moved to top */}
         <Switch>
           <Match when={tab() === "text"}>
             <div class={styles.searchBarContainer}>
@@ -192,15 +165,46 @@ function Summarize() {
                   }
                 }}
               ></textarea>
-              <button onClick={summarizeTextInput} class={styles.sendButton}>Send</button>
             </div>
           </Match>
           <Match when={tab() === "file"}>
-            <div style="margin-top:2vh;margin-left:2vh;">
-              <input type="file" id="fileInput" accept=".txt, .html., .docx" onChange={summarizeFileInput} />
+            <div class={styles.fileInputContainer}>
+              <textarea 
+                placeholder='File content will appear here after selection...'
+                readonly
+                class={styles.filePreview}
+              ></textarea>
+              <input type="file" id="fileInput" accept=".txt, .html., .docx" onChange={summarizeFileInput} class={styles.fileInput} />
             </div>
           </Match>
         </Switch>
+
+        {/* Control buttons row - moved to bottom */}
+        <div class={styles.controlsContainer}>
+          <div class={styles.controlsLeft}>
+            <label for="folderInput" id="modelInputLabel" class={selectedModel() === "" ? styles.unselectedModelButton : styles.selectedModelButton}>
+              {selectedModel() === "" ? "Select Model" : selectedModel()}
+            </label>
+            <input type="file" id="folderInput" class={styles.hidden} webkitdirectory multiple onChange={setupModel} />
+            <button 
+              class={tab() === "file" ? styles.selectedTab : styles.tab}
+              onClick={() => setTab("file")}
+            >
+              Summarize File
+            </button>
+            <button 
+              class={tab() === "text" ? styles.selectedTab : styles.tab}
+              onClick={() => setTab("text")}
+            >
+              Summarize Text
+            </button>
+          </div>
+          <div class={styles.controlsRight}>
+            {tab() === "text" && (
+              <button onClick={summarizeTextInput} class={styles.sendButton}>Send</button>
+            )}
+          </div>
+        </div>
 
       </div>
     </>

--- a/web_app/src/components/chats/chat-functionalities/Summarize.jsx
+++ b/web_app/src/components/chats/chat-functionalities/Summarize.jsx
@@ -16,6 +16,12 @@ function Summarize() {
 
   const [tab, setTab] = createSignal("text");
 
+  // Remove the autoResize function since we want fixed size
+  // const autoResize = (textarea) => {
+  //   textarea.style.height = 'auto';
+  //   textarea.style.height = Math.max(textarea.scrollHeight, 50) + 'px'; // minimum height of 50px
+  // };
+
   const setupModel = async () => {
 
     // disable uploading another model, and change the text to indicate a model is being loaded.
@@ -106,6 +112,9 @@ function Summarize() {
 
     chatContext.addMessage("Summarize: " + userMessage, true);
     inputTextArea.value = "";
+    
+    // No need to resize since we want fixed size
+    // autoResize(inputTextArea);
 
     let messageDate = chatContext.addMessage("Generating Message...", false, selectedModel());  // temporary message to indicate progress
     let output = await generator(userMessage, { max_new_tokens: 100});  // generate response
@@ -173,16 +182,18 @@ function Summarize() {
         {/* dynamic input UI */}
         <Switch>
           <Match when={tab() === "text"}>
-            <textarea id="inputTextArea" 
-              placeholder='Enter text to summarize here...'
-              onKeyDown={e => {
-                if (e.key === 'Enter' && !e.shiftKey) {
-                  e.preventDefault();
-                  summarizeTextInput();
-                }
-              }}
-            ></textarea>
-            <button onClick={summarizeTextInput} class={styles.sendButton}>Send</button>
+            <div class={styles.searchBarContainer}>
+              <textarea id="inputTextArea" 
+                placeholder='Enter text to summarize here...'
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    summarizeTextInput();
+                  }
+                }}
+              ></textarea>
+              <button onClick={summarizeTextInput} class={styles.sendButton}>Send</button>
+            </div>
           </Match>
           <Match when={tab() === "file"}>
             <div style="margin-top:2vh;margin-left:2vh;">

--- a/web_app/src/components/chats/chat-functionalities/Summarize.module.css
+++ b/web_app/src/components/chats/chat-functionalities/Summarize.module.css
@@ -1,4 +1,3 @@
-
 .inputContainer {
   grid-area: input;
   background-color: #191919;
@@ -6,11 +5,9 @@
   border-top: 1px solid black;
   position: relative;
 }
-
 .hidden {
   display: none;
 }
-
 .unselectedModelButton {
   border: 1px solid #474747;
   border-radius: 3px;
@@ -22,12 +19,10 @@
   margin-right: 3vh;
   border-color: darkred;
 }
-
 .unselectedModelButton:hover {
   border-color: firebrick;
   cursor: pointer;
 }
-
 .selectedModelButton {
   border: 1px solid #474747;
   border-radius: 3px;
@@ -39,12 +34,10 @@
   margin-right: 3vh;
   border-color: darkgreen;
 }
-
 .selectedModelButton:hover {
   border-color: lightblue;
   cursor: pointer;
 }
-
 .tab {
   border: 1px solid #474747;
   border-radius: 3px;
@@ -54,12 +47,10 @@
   padding-right: 2vh;
   color: white;
 }
-
 .tab:hover {
   cursor: pointer;
   border-color: green;
 }
-
 .selectedTab {
   border: 1px solid #474747;
   border-radius: 3px;
@@ -70,12 +61,10 @@
   color: white;
   border-color: darkgreen;
 }
-
 .selectedTab:hover {
   cursor: pointer;
   border-color: green;
 }
-
 .inputContainer textarea {
   margin-top: 1vh;
   margin-left: 1vh;
@@ -84,6 +73,60 @@
   font-size: 16px;
   box-sizing: border-box;
   resize: none;
+  border-radius: 35px; /* Keep the rounded corners */
+  border: 1px solid #474747;
+  background-color: #292929;
+  color: white;
+  padding: 12px 80px 12px 20px; /* Padding with space for button */
+  overflow-y: auto; /* Make it scrollable when content exceeds height */
+}
+
+.inputContainer textarea:focus {
+  outline: none;
+  border-color: lightblue;
+}
+
+/* Custom scrollbar styling */
+.inputContainer textarea::-webkit-scrollbar {
+  width: 8px;
+}
+
+.inputContainer textarea::-webkit-scrollbar-track {
+  background: #191919;
+  border-radius: 4px;
+}
+
+.inputContainer textarea::-webkit-scrollbar-thumb {
+  background: #474747;
+  border-radius: 4px;
+}
+
+.inputContainer textarea::-webkit-scrollbar-thumb:hover {
+  background: #666666;
+}
+
+.inputContainer textarea:focus {
+  outline: none;
+  border-color: lightblue;
+}
+
+/* Show scrollbar when content exceeds max-height */
+.inputContainer textarea::-webkit-scrollbar {
+  width: 8px;
+}
+
+.inputContainer textarea::-webkit-scrollbar-track {
+  background: #191919;
+  border-radius: 4px;
+}
+
+.inputContainer textarea::-webkit-scrollbar-thumb {
+  background: #474747;
+  border-radius: 4px;
+}
+
+.inputContainer textarea::-webkit-scrollbar-thumb:hover {
+  background: #666666;
 }
 
 .sendButton {
@@ -98,7 +141,16 @@
   padding-right: 3vh;
   color: white;
 }
+.sendButton:hover {
+  cursor: pointer;
+  border-color: lightblue;
+}
 
+.sendIcon {
+  width: 18px;
+  height: 18px;
+  filter: brightness(0) invert(1); /* Makes any image white */
+}
 .sendButton:hover {
   cursor: pointer;
   border-color: lightblue;

--- a/web_app/src/components/chats/chat-functionalities/Summarize.module.css
+++ b/web_app/src/components/chats/chat-functionalities/Summarize.module.css
@@ -4,10 +4,15 @@
   padding: 1vh;
   border-top: 1px solid black;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
+
 .hidden {
   display: none;
 }
+
 .unselectedModelButton {
   border: 1px solid #474747;
   border-radius: 3px;
@@ -19,10 +24,12 @@
   margin-right: 3vh;
   border-color: darkred;
 }
+
 .unselectedModelButton:hover {
   border-color: firebrick;
   cursor: pointer;
 }
+
 .selectedModelButton {
   border: 1px solid #474747;
   border-radius: 3px;
@@ -34,10 +41,12 @@
   margin-right: 3vh;
   border-color: darkgreen;
 }
+
 .selectedModelButton:hover {
   border-color: lightblue;
   cursor: pointer;
 }
+
 .tab {
   border: 1px solid #474747;
   border-radius: 3px;
@@ -47,10 +56,12 @@
   padding-right: 2vh;
   color: white;
 }
+
 .tab:hover {
   cursor: pointer;
   border-color: green;
 }
+
 .selectedTab {
   border: 1px solid #474747;
   border-radius: 3px;
@@ -61,97 +72,114 @@
   color: white;
   border-color: darkgreen;
 }
+
 .selectedTab:hover {
   cursor: pointer;
   border-color: green;
 }
+
+/* main content area which expands to fill space */
+.searchBarContainer,
+.fileInputContainer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  margin-bottom: 3vh; /* more space for housing additional controls below text entry area */
+}
+
 .inputContainer textarea {
-  margin-top: 1vh;
-  margin-left: 1vh;
-  width: 95%;
-  height: 17vh;
+  flex: 1;
+  width: 100%;
+  min-height: 15vh;
   font-size: 16px;
   box-sizing: border-box;
   resize: none;
-  border-radius: 35px; /* Keep the rounded corners */
+  border-radius: 10px;
   border: 1px solid #474747;
   background-color: #292929;
   color: white;
-  padding: 12px 80px 12px 20px; /* Padding with space for button */
-  overflow-y: auto; /* Make it scrollable when content exceeds height */
+  padding: 12px 20px;
+  overflow-y: auto; /* make it scrollable when content exceeds max height */
 }
 
 .inputContainer textarea:focus {
   outline: none;
   border-color: lightblue;
+}
+
+.fileInput {
+  padding: 1vh;
+  border: 1px solid #474747;
+  border-radius: 3px;
+  background-color: #292929;
+  color: white;
 }
 
 /* Custom scrollbar styling */
-.inputContainer textarea::-webkit-scrollbar {
+.inputContainer textarea::-webkit-scrollbar,
+.filePreview::-webkit-scrollbar {
   width: 8px;
 }
 
-.inputContainer textarea::-webkit-scrollbar-track {
+.inputContainer textarea::-webkit-scrollbar-track,
+.filePreview::-webkit-scrollbar-track {
   background: #191919;
   border-radius: 4px;
 }
 
-.inputContainer textarea::-webkit-scrollbar-thumb {
+.inputContainer textarea::-webkit-scrollbar-thumb,
+.filePreview::-webkit-scrollbar-thumb {
   background: #474747;
   border-radius: 4px;
 }
 
-.inputContainer textarea::-webkit-scrollbar-thumb:hover {
-  background: #666666;
-}
-
-.inputContainer textarea:focus {
-  outline: none;
-  border-color: lightblue;
-}
-
-/* Show scrollbar when content exceeds max-height */
-.inputContainer textarea::-webkit-scrollbar {
-  width: 8px;
-}
-
-.inputContainer textarea::-webkit-scrollbar-track {
-  background: #191919;
-  border-radius: 4px;
-}
-
-.inputContainer textarea::-webkit-scrollbar-thumb {
-  background: #474747;
-  border-radius: 4px;
-}
-
-.inputContainer textarea::-webkit-scrollbar-thumb:hover {
+.inputContainer textarea::-webkit-scrollbar-thumb:hover,
+.filePreview::-webkit-scrollbar-thumb:hover {
   background: #666666;
 }
 
 .sendButton {
-  position: absolute;
-  bottom: 1vh;
-  right: 9vh;
   border: 1px solid #474747;
   border-radius: 3px;
   background-color: #292929;
   padding: 1vh;
-  padding-left: 3vh;
-  padding-right: 3vh;
+  padding-left: 2vh;
+  padding-right: 2vh;
   color: white;
 }
+
 .sendButton:hover {
   cursor: pointer;
   border-color: lightblue;
 }
 
-.sendIcon {
-  width: 18px;
-  height: 18px;
-  filter: brightness(0) invert(1); /* Makes any image white */
-}
 .sendButton:hover {
   cursor: pointer;
   border-color: lightblue;
+}
+
+/* Controls container at the bottom */
+.controlsContainer {
+  display: flex;
+  gap: 1vh;
+  align-items: center;
+  justify-content: space-between; /* Space between left and right groups */
+  padding: 2vh 0; /* More vertical padding */
+  border-top: 1px solid #474747;
+  border-bottom: 1px solid #474747; /* Add bottom border */
+  margin-top: auto; /* Push to bottom */
+  background-color: #191919; /* Ensure consistent background */
+}
+
+.controlsLeft {
+  display: flex;
+  gap: 1vh;
+  align-items: center;
+}
+
+.controlsRight {
+  display: flex;
+  gap: 1vh;
+  align-items: center;
 }


### PR DESCRIPTION
chat history with temp styling to hide old buttons within a sub menu with styling:
![image](https://github.com/user-attachments/assets/1b8e67af-9b0c-486f-b074-00d95bfd06f5)

this is what the new text entry field looks like, with styled buttons, scroll support and changed colouring to match scheme:
![image](https://github.com/user-attachments/assets/225a3deb-8522-48bb-9356-512a74be2009)

fact of the matter is that this was a bit of a rush job for a proof of concept, there is considerable technical debt such as some styling elements being the chat history ui will need to be changed again in future as i feel it doesn't look "right". Also the changes around the ui for the text entry were only applied to summarisation not for general or question answering all of which will be done in a later sprint.